### PR TITLE
docs: update description of namespace to 29 bytes = 28+1

### DIFF
--- a/ev-stacks/deploy-rollkit.sh
+++ b/ev-stacks/deploy-rollkit.sh
@@ -789,7 +789,7 @@ setup_da_celestia_configuration() {
 	if grep -q "^DA_NAMESPACE=$" "$env_file" || ! grep -q "^DA_NAMESPACE=" "$env_file"; then
 		echo ""
 		echo "🌌 Namespace is required for Celestia data availability."
-		echo "This should be a 29-byte identifier used to categorize and retrieve blobs, composed of a 1-byte version and a 28-byte ID. (Full documentation: https://celestiaorg.github.io/celestia-app/specs/namespace.html)."
+echo "This should be a 29-byte identifier (entered as a 58-character hex string) used to categorize and retrieve blobs, composed of a 1-byte version and a 28-byte ID. (Full documentation: https://celestiaorg.github.io/celestia-app/specs/namespace.html)."
 		echo "Example: '000000000000000000000000000000000000002737d4d967c7ca526dd5'"
 		read -r da_namespace
 

--- a/ev-stacks/deploy-rollkit.sh
+++ b/ev-stacks/deploy-rollkit.sh
@@ -789,7 +789,7 @@ setup_da_celestia_configuration() {
 	if grep -q "^DA_NAMESPACE=$" "$env_file" || ! grep -q "^DA_NAMESPACE=" "$env_file"; then
 		echo ""
 		echo "🌌 Namespace is required for Celestia data availability."
-		echo "This should be a 28-byte identifier used to categorize and retrieve blobs, composed of a 1-byte version and a 27-byte ID. (Full documentation: https://celestiaorg.github.io/celestia-app/specs/namespace.html)."
+		echo "This should be a 29-byte identifier used to categorize and retrieve blobs, composed of a 1-byte version and a 28-byte ID. (Full documentation: https://celestiaorg.github.io/celestia-app/specs/namespace.html)."
 		echo "Example: '000000000000000000000000000000000000002737d4d967c7ca526dd5'"
 		read -r da_namespace
 


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

While using this script, I saw errors on sequencer and light node:

```
celestia-node  | 2025-07-23T03:09:58.245Z	WARN	rpc	go-jsonrpc@v0.6.0/handler.go:474	error in RPC call to 'da.SubmitWithOptions': invalid namespace length: 27. Must be 29 bytes

single-sequencer    | 2025-07-23T03:39:03.579Z	ERROR	main	jsonrpc/client.go:188	RPC call failedmethodSubmitWithOptionserrorinvalid namespace length: 28. Must be 29 bytes
celestia-node  | 2025-07-23T03:39:45.191Z	WARN	rpc	go-jsonrpc@v0.6.0/handler.go:474	error in RPC call to 'da.SubmitWithOptions': invalid namespace length: 28. Must be 29 bytes
```

I realized the guidance is wrong, but the namespace example in the script is correct. this PR edits the guidance/docs in script.
<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->
